### PR TITLE
Update operators and macros using setattr

### DIFF
--- a/scidbpy/afl.py
+++ b/scidbpy/afl.py
@@ -4,11 +4,9 @@ from __future__ import absolute_import, print_function, division, unicode_litera
 
 import sys
 import threading
-import subprocess
-import re
 
 from . import SciDBArray
-from .afldb import operators as operators_doc_str
+from .afldb import operators
 from ._py3k_compat import string_type
 
 _mod = sys.modules[__name__]
@@ -172,16 +170,7 @@ class AFLNamespace(object):
         return self.store(self.redimension(arr_in, arr_out),
                           arr_out)
 
-'''
- Start filling up the AFL namespace in the following manner:
-	- manual input of infix_functions
-	- manual input of scalar functions
-	- manual input of functions from other libraries
- 	- automated addition of iquery supported macros
-	- automated addition of iquery supported operators (and also fill in DocStrings info from
-			corresponding afldb.py entry if available) 	
-'''
-operators = []
+
 # tuple of (python AFL name, scidb token) for binary infix functions
 infix_functions = [('as_', 'as'), ('add', '+'),
                    ('sub', '-'), ('mul', '*'), ('div', '/'),
@@ -213,38 +202,6 @@ for f in functions:
 '''
 for op in ['gemm', 'gesvd']:
     operators.append(dict(name=op, signature=[], doc=''))
-
-'''
- add the AFL macros by running the following query:
- iquery -aq "list('macros')"
-'''
-iqout = subprocess.check_output("iquery -aq \"list('macros')\"", shell=True, stderr=subprocess.STDOUT)
-regex = r" *'([^']*)' *, *.*"		# regular expression to extract the first occurence with single 
-					#	... quotes 'asdf'
-macros = re.findall(regex, iqout)	# store regex matches in a list
-for macro in macros:
-    operators.append(dict(name=macro, signature=[], doc=''))
-
-'''
- add the AFL operators by running the following query:
- iquery -aq "list('operators')"
-'''
-iqout = subprocess.check_output("iquery -aq \"list('operators')\"", \
-				shell=True, stderr=subprocess.STDOUT)
-regex = r" *'([^']*)' *, *.*"		# regular expression to extract the first occurence with single 
-					#	... quotes 'asdf'
-operator_list = re.findall(regex, iqout)	# store regex matches in a list
-for opname in operator_list:
-    # now check if there is a DocString existing for this particular operator
-    found = False
-    for entry in operators_doc_str:
-        if entry['name'] == opname:
-            operators.append(dict(name=opname, signature=entry['signature'], doc=entry['doc']))
-            found = True
-            continue
-    
-    if found != True:	# if DocString was not found in `afldb.py`
-        operators.append(dict(name=opname, signature=[], doc=''))
 
 '''
  for documentation purposes, create operator classes


### PR DESCRIPTION
Following up on #85 

I just merged @ChrisBeaumont 's suggestion of placement of code for updating operators and macros after `connect()` and my idea that `setattr` would need to be called in this fork. Everything (i.e. all the unit tests, importing of macros and updated operators) seems to be working fine now. 

Please review.