### PR TITLE
changes for SciDB 15.12

### DIFF
--- a/scidbpy/parse.py
+++ b/scidbpy/parse.py
@@ -190,7 +190,7 @@ def _nonstring_attribute_dict(array, **kwargs):
             result[nm] = att
         else:
             good = att['mask'] == 255
-            result[nm] = np.where(good, att['data'], NULLS[typ])
+            result[nm] = np.where(good, att['data'], NULLS[typ]).astype(typemap[typ])
 
         if typ == 'datetimetz':
             result[nm] = result[nm]['time'] - result[nm]['tz']

--- a/scidbpy/scidbarray.py
+++ b/scidbpy/scidbarray.py
@@ -166,7 +166,7 @@ class sdbtype(object):
     @classmethod
     def from_full_rep(cls, rep):
         schema = '<%s>' % (','.join('%s: %s %s' %
-                                    (nm, typ, 'NULL' if null else '')
+                                    (nm, typ, '' if null else 'NOT NULL')
                                     for nm, typ, null in rep))
         return cls(schema)
 
@@ -195,7 +195,7 @@ class sdbtype(object):
 
         names = [str(s[0]) for s in sdbL]
         dtypes = [s[1].split()[0] for s in sdbL]
-        nullable = ['null' in (''.join(s[1].split()[1:])).lower()
+        nullable = ['not null' not in (' '.join(s[1].split()[1:])).lower()
                     for s in sdbL]
         return list(zip(names, dtypes, nullable))
 
@@ -222,7 +222,7 @@ class sdbtype(object):
 
     @classmethod
     def _dtype_to_schema(cls, dtype):
-        """Convert a scidb type schema to a numpy dtype
+        """Convert a numpy dtype schema to a scidb type
 
         Parameters
         ----------
@@ -239,7 +239,7 @@ class sdbtype(object):
         # Hack: if we re-encode this as a dtype, then de-encode again, numpy
         #       will add default names where they are missing
         dtype = _dtype(dtype).descr
-        pairs = ["{0}:{1}".format(d[0], _sdb_type(d[1])) for d in dtype]
+        pairs = ["{0}:{1} NOT NULL".format(d[0], _sdb_type(d[1])) for d in dtype]
         return '<{0}>'.format(','.join(pairs))
 
 

--- a/scidbpy/tests/test_arithmetic.py
+++ b/scidbpy/tests/test_arithmetic.py
@@ -117,8 +117,8 @@ def test_sparse_mischunked():
     def check_join_op(op):
         A = rand(3, 4, density=0.5)
         B = rand(3, 4, density=0.5)
-        Asdb = sdb.from_sparse(A).redimension('<f0:double>[i0=0:2,10,0,i1=0:3,10,0]')
-        Bsdb = sdb.from_sparse(B).redimension('<f0:double>[i0=0:2,2,1,i1=0:3,2,1]')
+        Asdb = sdb.from_sparse(A).redimension('<f0:double NOT NULL>[i0=0:2,10,0,i1=0:3,10,0]')
+        Bsdb = sdb.from_sparse(B).redimension('<f0:double NOT NULL>[i0=0:2,2,1,i1=0:3,2,1]')
         C = op(Asdb, Bsdb)
         expected = op(A.toarray(), B.toarray())
         assert_allclose(C.toarray(), expected, rtol=RTOL)
@@ -131,8 +131,8 @@ def test_sparse_mischunked():
 def test_dense_mischunked():
 
     def check_join_op(op):
-        A = sdb.random((3, 4)).redimension('<f0:double>[i0=0:2,10,0,i1=0:3,10,0]')
-        B = sdb.random((3, 4)).redimension('<f0:double>[i0=0:2,2,1,i1=0:3,2,1]')
+        A = sdb.random((3, 4)).redimension('<f0:double NOT NULL>[i0=0:2,10,0,i1=0:3,10,0]')
+        B = sdb.random((3, 4)).redimension('<f0:double NOT NULL>[i0=0:2,2,1,i1=0:3,2,1]')
         C = op(A, B)
         expected = op(A.toarray(), B.toarray())
         assert_allclose(C.toarray(), expected, rtol=RTOL)

--- a/scidbpy/tests/test_basic.py
+++ b/scidbpy/tests/test_basic.py
@@ -321,9 +321,11 @@ def test_svd():
     U, S, VT = sdb.svd(A)
     U2, S2, VT2 = np.linalg.svd(A.toarray(), full_matrices=False)
 
-    assert_allclose(U.toarray(), U2, rtol=RTOL)
-    assert_allclose(S.toarray(), S2, rtol=RTOL)
-    assert_allclose(VT.toarray(), VT2, rtol=RTOL)
+    assert_allclose(np.mat(U.toarray()) * np.diag(S.toarray()) * np.mat(VT.toarray()), np.mat(A.toarray()), rtol=RTOL)
+
+    assert_allclose(np.absolute(U.toarray()), np.absolute(U2), rtol=RTOL)
+    assert_allclose(np.absolute(S.toarray()), np.absolute(S2), rtol=RTOL)
+    assert_allclose(np.absolute(VT.toarray()), np.absolute(VT2), rtol=RTOL)
 
 
 def test_abs():


### PR DESCRIPTION
Proposed changes for SciDB-Py due to changes in SciDB 15.12:

- Earlier attributes were NOT NULL-able by default. In SciDB15.12, attributes are NULL-able by default
- Correspondingly, the schema definition of an array also changes:
```
foo@1<v1:float NULL DEFAULT null,v2:double,v3:string> [i=1:50,10,0]
```
is now
```
foo@1<v1:float,v2:double NOT NULL,v3:string NOT NULL> [i=1:50,10,0]
```

Made changes to the package and test suite to handle these changes. Also made a small but important change in `scidpy/parse.py`:
```
result[nm] = np.where(good, att['data'], NULLS[typ]).astype(typemap[typ])
```
For `int32` or `int64` arrays, there is no numpy version of nulls, so `nan` was being used. However `nan` was forcing the output of `np.where` to be upconverted to `float` or `double`, thus resulting in many failed tests in `test_parse.py`. Added an `astype` function call to cast to the requested datatype.

**NOTE**: `master` will now track SciDB 15.12. The code for SciDB15.7 lives in the branch `scidb15.7` 
