### PR TITLE
Fix SciDBArray __repr__ to contain schema

### DIFF
--- a/scidbpy/scidbarray.py
+++ b/scidbpy/scidbarray.py
@@ -770,7 +770,7 @@ class SciDBArray(object):
 
     def __repr__(self):
         show = self.interface._show_array(self.name, fmt='csv').split('\n')
-        return "SciDBArray({0})".format(show[1])
+        return "SciDBArray({0})".format(show[0])
 
     def contents(self, **kwargs):
         """


### PR DESCRIPTION
This PR fixes `__repr__` for `SciDBArray` to include the schema of the SciDB array. The schema is fetched, but due to the wrong index being used it is not contained in the result of `__repr__`.

Before the patch:
```python
>>> db.wrap_array('foo')
SciDBArray()
```
After the patch:
```python
>>> db.wrap_array('foo')
SciDBArray('foo<x:int64> [i=0:9:0:10]')
```