### PR TITLE
Encode strings using utf-8 when uploading

### DIFF
--- a/scidbpy/schema.py
+++ b/scidbpy/schema.py
@@ -270,7 +270,7 @@ class Attribute(object):
         if self.dtype_val == numpy.object:
             if self.type_name == 'string':
                 buf = b''.join(
-                    [struct.pack(Attribute._length_fmt, len(val) + 1),
+                    [struct.pack(Attribute._length_fmt, len(val.encode()) + 1),
                      val.encode(),
                      b'\x00'])
             elif self.type_name == 'binary':

--- a/scidbpy/schema.py
+++ b/scidbpy/schema.py
@@ -269,9 +269,10 @@ class Attribute(object):
     def tobytes(self, val):
         if self.dtype_val == numpy.object:
             if self.type_name == 'string':
+                val_enc = val.encode('utf-8')
                 buf = b''.join(
-                    [struct.pack(Attribute._length_fmt, len(val.encode()) + 1),
-                     val.encode(),
+                    [struct.pack(Attribute._length_fmt, len(val_enc) + 1),
+                     val_enc,
                      b'\x00'])
             elif self.type_name == 'binary':
                 buf = b''.join(

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1163,7 +1163,7 @@ class TestUpload:
         db.remove('foo')
 
     def test_load_non_ascii(self, db):
-        data = pandas.DataFrame({'foo': [b'\xc2\xb5'.decode() + 'bar']})
+        data = pandas.DataFrame({'foo': [b'\xc2\xb5'.decode('utf-8') + 'bar']})
         assert type(
             db.input('<foo:string not null>[i]',
                      upload_data=data.to_records(index=False)).store(

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1162,6 +1162,14 @@ class TestUpload:
             db.load('foo', '/tmp/foo') == Array)
         db.remove('foo')
 
+    def test_load_non_ascii(self, db):
+        data = pandas.DataFrame({'foo': ['µbar']})
+        assert type(
+            db.input('<foo:string not null>[i]',
+                     upload_data=data.to_records(index=False)).store(
+                         'foo')) == Array)
+        db.remove('foo')
+
 
 class TestCreate:
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1163,7 +1163,7 @@ class TestUpload:
         db.remove('foo')
 
     def test_load_non_ascii(self, db):
-        data = pandas.DataFrame({'foo': ['µbar']})
+        data = pandas.DataFrame({'foo': [b'\xc2\xb5'.decode() + 'bar']})
         assert type(
             db.input('<foo:string not null>[i]',
                      upload_data=data.to_records(index=False)).store(

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1167,7 +1167,7 @@ class TestUpload:
         assert type(
             db.input('<foo:string not null>[i]',
                      upload_data=data.to_records(index=False)).store(
-                         'foo')) == Array)
+                         'foo') == Array)
         db.remove('foo')
 
 


### PR DESCRIPTION
* Fix for #142 
* Measure string length after encoding
* Use `utf-8` encoding, override the default ASCII encoding in Python 2.7 (`utf-8` is the default in Python 3.x)
* Add test - upload non-ASCII data to SciDB